### PR TITLE
Add MIT license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 Eudald Correig-Fraga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,17 @@ setup(
         "dev": DEV_REQUIRES,
         "all": RESEARCH_REQUIRES + DEV_REQUIRES,
     },
-    author="Eudald Correig",
+    author="Eudald Correig-Fraga",
     author_email="eudald.correig@urv.cat",
+    license="MIT",
     description="Research analysis tools for the Drosophila connectome project",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/eudald-seeslab/connectome",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    ],
 )


### PR DESCRIPTION
## Summary

- add an explicit MIT `LICENSE` file
- declare MIT licensing and scientific-Python classifiers in `setup.py`
- expand the package author name consistently

## Why

This makes the repository's reuse terms explicit for manuscript peer review, archival, and downstream users.

## Validation

- `python setup.py --name --version --author`
- `git diff --check`

This PR contains only licensing and package-metadata changes.